### PR TITLE
add DynamicColorIOS support

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -23,8 +23,10 @@ import android.view.ViewParent;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ReactCompoundViewGroup;
@@ -173,11 +175,17 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     }
 
     @ReactProp(name = "tintColor")
-    public void setTintColor(@Nullable Integer tintColor) {
-        if (tintColor == null) {
-            mTintColor = 0;
-        } else {
-            mTintColor = tintColor;
+    public void setTintColor(@Nullable Dynamic tintColor) {
+        switch (tintColor.getType()) {
+            case Null:
+                mTintColor = 0;
+                break;
+            case Map:
+                mTintColor = ColorPropConverter.getColor(tintColor.asMap(), getContext());
+                break;
+            case Number:
+                mTintColor = tintColor.asInt();
+                break;
         }
         invalidate();
         clearChildCache();

--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -78,12 +78,12 @@ class SvgViewManager extends ReactViewManager {
     }
 
     @ReactProp(name = "tintColor")
-    public void setTintColor(SvgView node, @Nullable Integer tintColor) {
+    public void setTintColor(SvgView node, @Nullable Dynamic tintColor) {
         node.setTintColor(tintColor);
     }
 
     @ReactProp(name = "color")
-    public void setColor(SvgView node, @Nullable Integer color) {
+    public void setColor(SvgView node, @Nullable Dynamic color) {
         node.setTintColor(color);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-native-svg",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "12.1.0",
+      "version": "12.2.0",
       "license": "MIT",
       "dependencies": {
         "css-select": "^2.1.0",
@@ -18324,11 +18324,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -18,6 +18,7 @@ import {
   ResponderProps,
   StrokeProps,
   TransformProps,
+  ProcessedDynamicColor,
 } from '../lib/extract/types';
 import extractResponder from '../lib/extract/extractResponder';
 import extractViewBox from '../lib/extract/extractViewBox';
@@ -183,7 +184,29 @@ export default class Svg extends Shape<
 
     extractResponder(props, props, this as ResponderInstanceProps);
 
-    const tint = extractColor(color);
+    let tint = extractColor(color);
+    if (typeof color === 'object' && color !== null) {
+      if ('dynamic' in color) {
+        let processedColor: ProcessedDynamicColor = {
+          dynamic: {
+            light: extractColor(color.dynamic.light) as number,
+            dark: extractColor(color.dynamic.dark) as number,
+          },
+        };
+        if (color.dynamic.highContrastLight) {
+          processedColor.dynamic.highContrastLight = extractColor(
+            color.dynamic.highContrastLight,
+          ) as number;
+        }
+        if (color.dynamic.highContrastDark) {
+          processedColor.dynamic.highContrastDark = extractColor(
+            color.dynamic.highContrastDark,
+          ) as number;
+        }
+        tint = processedColor;
+      }
+    }
+
     if (tint != null) {
       props.color = tint;
       props.tintColor = tint;

--- a/src/lib/extract/extractBrush.ts
+++ b/src/lib/extract/extractBrush.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import extractColor, { integerColor } from './extractColor';
 import { Color, ProcessedDynamicColor } from './types';
 
@@ -40,7 +41,15 @@ export default function extractBrush(color?: Color) {
     return int32ARGBColor;
   }
   if (typeof color === 'string') {
-    if (color.indexOf('semantic|') === 0) {
+    if (color.indexOf('platform|') === 0) {
+      return [
+        0,
+        Platform.select({
+          ios: { semantic: color.split('|').slice(1) },
+          android: { resource_paths: color.split('|').slice(1) },
+        }),
+      ];
+    } else if (color.indexOf('semantic|') === 0) {
       return [0, { semantic: color.split('|').slice(1) }];
     } else if (color.indexOf('resource_paths|') === 0) {
       return [0, { resource_paths: color.split('|').slice(1) }];

--- a/src/lib/extract/types.ts
+++ b/src/lib/extract/types.ts
@@ -8,7 +8,23 @@ export type NumberArray = NumberProp[] | NumberProp;
 export type rgbaArray = number[];
 // int32ARGBColor = 0xaarrggbb
 export type Int32ARGBColor = number;
-export type Color = Int32ARGBColor | rgbaArray | string;
+export type Color = Int32ARGBColor | rgbaArray | string | DynamicColor;
+export type DynamicColor = {
+  dynamic: {
+    light: Color;
+    dark: Color;
+    highContrastLight?: Color;
+    highContrastDark?: Color;
+  };
+};
+export type ProcessedDynamicColor = {
+  dynamic: {
+    light: Int32ARGBColor;
+    dark: Int32ARGBColor;
+    highContrastLight?: Int32ARGBColor;
+    highContrastDark?: Int32ARGBColor;
+  };
+};
 
 export type Linecap = 'butt' | 'square' | 'round';
 export type Linejoin = 'miter' | 'bevel' | 'round';


### PR DESCRIPTION
# Summary

- Add DynamicColorIOS support 

- Add DynamicColorIOS and PlatformColor support in svg xml attr
```js
DynamicColorIOS({
                  light: "red",
                  dark: 'white',
                  highContrastLight:"green"
                  highContrastDark:'blue',
                })
"dynamic|red|white|green|blue"

PlatformColor("label", "@android:color/primary_text_dark")
"semantic|label|@android:color/primary_text_dark"
"resource_paths|label|@android:color/primary_text_dark"
"platform|label|@android:color/primary_text_dark"

```
- Fix PlatformColor bug on Android


